### PR TITLE
chore: ranking ワークフローの Node.js バージョンと Actions を更新

### DIFF
--- a/.github/workflows/ranking.yml
+++ b/.github/workflows/ranking.yml
@@ -9,10 +9,10 @@ jobs:
   set-ranking:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3.7.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
       - name: Install dependencies
         run: npm install
       - name: Set Ranking


### PR DESCRIPTION
ranking.yml で使用している Node.js バージョンおよび GitHub Actions を更新しました。

## 変更内容
 変更内容
  - `node-version` を 18 → 24 に更新（`package.json` の `engines: ">=24.x"` に合わせる）
  - `actions/checkout@v3` → `@v4` に更新（v3 は Node.js 16 ランタイムで非推奨）
  - `actions/setup-node@v3.7.0` → `@v4` に更新（同上）